### PR TITLE
fix/py2_compatibility

### DIFF
--- a/pymarketstore/results.py
+++ b/pymarketstore/results.py
@@ -4,10 +4,13 @@ import six
 
 
 def decode(packed):
+
     dt = np.dtype([
-        (colname, coltype)
+        (colname if isinstance(colname, str) else colname.encode("utf-8"),
+         coltype if isinstance(colname, str) else coltype.encode("utf-8"))
         for colname, coltype in zip(packed['names'], packed['types'])
     ])
+
     array = np.empty((packed['length'],), dtype=dt)
     for idx, name in enumerate(dt.names):
         array[name] = np.frombuffer(packed['data'][idx], dtype=dt[idx])


### PR DESCRIPTION
np.dtype expects bytes and python 2 converts it to unicode.

http://numpy-discussion.10968.n7.nabble.com/Question-about-dtype-td39275.html