### PR TITLE
feature/str_keys

### DIFF
--- a/pymarketstore/results.py
+++ b/pymarketstore/results.py
@@ -25,7 +25,7 @@ def decode_responses(responses):
         array = decode(packed)
         for tbk, start_idx in six.iteritems(packed['startindex']):
             length = packed['lengths'][tbk]
-            key = tbk.split(':')[0]
+            key = str(tbk.split(':')[0])
             array_dict[key] = array[start_idx:start_idx + length]
         results.append(array_dict)
     return results


### PR DESCRIPTION
# Summary
- If using python2 this will ensure the returned type will be unicode

# Reproduce error
Executing on python2:
```
param = pymkts.Params("AAPL",
                     '1H',
                     'OHLCV')
qr = client.query(param).first().df()
print(qr.symbols())
print(qr.all())
```

returns:
```
[u'AAPL']
{u'AAPL/1Min/OHLCV': DataSet(key=AAPL/1Min/OHLCV, shape=(481565,), dtype=[('Epoch', '<i8'), ('Open', '<f4'), ('High', '<f4'), ('Low', '<f4'), ('Close', '<f4'), ('Volume', '<i4')])}
```
So this effectively creates a mismatch betwen the types of the queried keys and the returned keys.