### PR TITLE
add QueryReply.df() method for collapsing results of length 1

### DIFF
--- a/pymarketstore/results.py
+++ b/pymarketstore/results.py
@@ -111,6 +111,19 @@ class QueryReply(object):
     def timezone(self):
         return self.reply['timezone']
 
+    def df(self):
+        """
+        If the results of this query are one row per symbol, then collapse them
+        into a single DataFrame keyed by symbol with columns of the queried
+        attribute groups (eg OHLCV -> (Open, High, Low, Close, Volume))
+        """
+        if len(self.first().array) != 1:
+            raise NotImplementedError
+
+        return pd.DataFrame([ds.array.tolist()[0] for ds in self.all().values()],
+                            index=list(self.by_symbols().keys()),
+                            columns=self.first().array.dtype.names)
+
     def first(self):
         return self.results[0].first()
 

--- a/pymarketstore/results.py
+++ b/pymarketstore/results.py
@@ -113,16 +113,23 @@ class QueryReply(object):
 
     def df(self):
         """
+        If there's a single result from this query, return its DataFrame.
+
         If the results of this query are one row per symbol, then collapse them
         into a single DataFrame keyed by symbol with columns of the queried
         attribute groups (eg OHLCV -> (Open, High, Low, Close, Volume))
-        """
-        if len(self.first().array) != 1:
-            raise NotImplementedError
 
-        return pd.DataFrame([ds.array.tolist()[0] for ds in self.all().values()],
-                            index=list(self.by_symbols().keys()),
-                            columns=self.first().array.dtype.names)
+        Otherwise, raises NotImplementedError.
+        """
+        if len(self.all()) == 1:
+            return self.first().df()
+        elif len(self.first().array) == 1:
+            return pd.DataFrame([ds.array.tolist()[0] for ds in self.all().values()],
+                                index=list(self.by_symbols().keys()),
+                                columns=self.first().array.dtype.names)
+
+        # otherwise we don't know how to support this
+        raise NotImplementedError
 
     def first(self):
         return self.results[0].first()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,7 +1,18 @@
+import pandas as pd
+
 from ast import literal_eval
 from pymarketstore import results
 import imp
 imp.reload(results)
+
+
+def assert_dataframes_equal(got, expected):
+    for i in expected.index:
+        row_bool = expected.loc[i] == got.loc[i]
+        if not row_bool.all():
+            print('got:\n', got.loc[i])
+            print('expected:\n', expected.loc[i])
+            raise AssertionError
 
 
 testdata1 = literal_eval(r"""
@@ -55,3 +66,13 @@ def test_results():
 
     reply = results.QueryReply(testdata2)
     assert str(reply.first().df().index.tzinfo) == 'America/New_York'
+
+    expected = pd.DataFrame([
+        (pd.Timestamp('2018-01-17 06:17:00+00:00'), 11276.0, 11276.0, 11276.0, 11276.0, 1.283),
+        (pd.Timestamp('2018-01-17 06:17:00+00:00'), 1014.0, 1014.0, 1014.0, 1014.0,
+         13.597670090000001),
+    ],
+        columns=['Epoch', 'Open', 'High', 'Low', 'Close', 'Volume'],
+        index=['BTC', 'ETH'],
+    )
+    assert_dataframes_equal(reply.latest_df(), expected)


### PR DESCRIPTION
See docstring for description. The intended use case is for easy filtering, eg:

```
p = Params('*', '1D', 'OHLCV', limit=1)
results = client.query(p)
df = results.df()

filtered = df[df['Volume'] > 1e7]
filtered_p = Params(','.join(filtered.index), '1D', 'OHLCV')
filtered_results = client.query(filtered_p)
```

(First line of this example code assumes https://github.com/alpacahq/marketstore/pull/193)