### PR TITLE
validate timeframe is in a supported format

### DIFF
--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -49,8 +49,8 @@ class Params(object):
         if not isiterable(symbols):
             symbols = [symbols]
 
-        if not TIMEFRAME_RE.match(timeframe):
-            raise ValueError('Timeframe must be in the format of '
+        if not isinstance(timeframe, str) or not TIMEFRAME_RE.match(timeframe):
+            raise ValueError('Timeframe must be a string in the format of '
                              '^([0-9]+)(Sec|Min|H|D|W|M|Y)$')
 
         self.tbk = ','.join(symbols) + "/" + timeframe + "/" + attrgroup

--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -20,6 +20,8 @@ data_type_conv = {
     '<i8': 'q',
 }
 
+TIMEFRAME_RE = re.compile(r'^([0-9]+)(Sec|Min|H|D|W|M|Y)$')
+
 
 def isiterable(something):
     return isinstance(something, (list, tuple, set))
@@ -46,6 +48,11 @@ class Params(object):
                  limit=None, limit_from_start=None):
         if not isiterable(symbols):
             symbols = [symbols]
+
+        if not TIMEFRAME_RE.match(timeframe):
+            raise ValueError('Timeframe must be in the format of '
+                             '^([0-9]+)(Sec|Min|H|D|W|M|Y)$')
+
         self.tbk = ','.join(symbols) + "/" + timeframe + "/" + attrgroup
         self.key_category = None  # server default
         self.start = get_timestamp(start)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
-import pymarketstore as pymkts
-from pymarketstore import jsonrpc
 import numpy as np
+import pymarketstore as pymkts
+import pytest
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -9,10 +10,16 @@ import imp
 imp.reload(pymkts.client)
 
 
-def test_init():
+def test_params_init():
     p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
     tbk = "TSLA/1Min/OHLCV"
     assert p.tbk == tbk
+
+    for garbage in [None, 0, '', 'fail', 'minutely', 'hourly', 'daily', 'weekly',
+                    'monthly', 'yearly']:
+        with pytest.raises(ValueError) as e:
+            p = pymkts.Params('TSLA', garbage, 'OHLCV')
+        assert 'Timeframe must be a string in the format of' in str(e)
 
 
 def test_client_init():


### PR DESCRIPTION
This logic matches the [backend logic](https://github.com/alpacahq/marketstore/blob/master/utils/timeframe.go#L211). However looking at [timeframeDefs](https://github.com/alpacahq/marketstore/blob/master/utils/timeframe.go#L15), it's maybe possible the backend regex is missing the `S` and `T` shorthand identifiers?