### PR TITLE
RFC: a refactor attempt

### DIFF
--- a/pymarketstore/_compat.py
+++ b/pymarketstore/_compat.py
@@ -1,0 +1,10 @@
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    from inspect import getargspec as getfullargspec
+else:
+    from inspect import getfullargspec

--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -6,6 +6,7 @@ import requests
 import logging
 import six
 
+from ._compat import getfullargspec
 from .jsonrpc import JsonRpcClient, MsgpackRpcClient
 from .results import QueryReply
 from .stream import StreamConn
@@ -13,12 +14,13 @@ from .stream import StreamConn
 logger = logging.getLogger(__name__)
 
 
-data_type_conv = {
+DATA_TYPE_CONV = {
     '<f4': 'f',
     '<f8': 'd',
     '<i4': 'i',
     '<i8': 'q',
 }
+TIMEFRAME_RE = re.compile(r'^([0-9]+)(Sec|Min|H|D|W|M|Y)$')
 
 
 def isiterable(something):
@@ -44,32 +46,95 @@ class Params(object):
     def __init__(self, symbols, timeframe, attrgroup,
                  start=None, end=None,
                  limit=None, limit_from_start=None):
-        if not isiterable(symbols):
-            symbols = [symbols]
-        self.tbk = ','.join(symbols) + "/" + timeframe + "/" + attrgroup
-        self.key_category = None  # server default
-        self.start = get_timestamp(start)
-        self.end = get_timestamp(end)
+        self.symbols = symbols
+        self.timeframe = timeframe
+        self.attrgroup = attrgroup
+        self._key_category = 'Symbol/Timeframe/AttributeGroup'
+
+        self.start = start
+        self.end = end
         self.limit = limit
         self.limit_from_start = limit_from_start
         self.functions = None
 
+    @property
+    def tbk(self):
+        return '/'.join([
+            ','.join(self.symbols),
+            self.timeframe,
+            self.attrgroup,
+        ])
+
+    @property
+    def symbols(self):
+        return self._symbols
+
+    @symbols.setter
+    def symbols(self, symbols):
+        self._symbols = symbols if isiterable(symbols) else [symbols]
+
+    @property
+    def timeframe(self):
+        return self._timeframe
+
+    @timeframe.setter
+    def timeframe(self, timeframe):
+        if not TIMEFRAME_RE.match(timeframe):
+            raise ValueError('Timeframe must be in the format of '
+                             '^([0-9]+)(Sec|Min|H|D|W|M|Y)$')
+
+        self._timeframe = timeframe
+
+    @property
+    def start(self):
+        return self._start
+
+    @start.setter
+    def start(self, start):
+        self._start = get_timestamp(start)
+
+    @property
+    def end(self):
+        return self._end
+
+    @end.setter
+    def end(self, end):
+        self._end = get_timestamp(end)
+
     def set(self, key, val):
-        if not hasattr(self, key):
-            raise AttributeError()
-        if key in ('start', 'end'):
-            setattr(self, key, get_timestamp(val))
-        else:
-            setattr(self, key, val)
+        if key not in getfullargspec(self.__init__).args[1:]:
+            raise AttributeError(key)
+
+        setattr(self, key, val)
         return self
 
+    def to_rpc(self):
+        query = dict(
+            destination=self.tbk,
+            key_category=self._key_category,
+            epoch_start=(None if self.start is None
+                         else int(self.start.value / 10**9)),
+            epoch_end=(None if self.end is None
+                       else int(self.end.value / 10**9)),
+            limit_record_count=(None if self.limit is None
+                                else int(self.limit)),
+            limit_from_start=(None if self.limit_from_start is None
+                              else bool(self.limit_from_start)),
+            functions=self.functions
+        )
+        return {k: v for k, v in six.iteritems(query) if v is not None}
+
     def __repr__(self):
-        content = ('tbk={}, start={}, end={}, '.format(
-            self.tbk, self.start, self.end,
-        ) +
-            'limit={}, '.format(self.limit) +
-            'limit_from_start={}'.format(self.limit_from_start))
-        return 'Params({})'.format(content)
+        return (
+            'Params('
+                'symbols={!r}, timeframe={!r}, attrgroup={!r}, '
+                'start={!r}, end={!r}, '
+                'limit={!r}, limit_from_start={!r}'
+            ')'.format(
+                self.symbols, self.timeframe, self.attrgroup,
+                self.start, self.end,
+                self.limit, self.limit_from_start
+            ))
 
 
 class Client(object):
@@ -81,22 +146,18 @@ class Client(object):
 
     def _request(self, method, **query):
         try:
-            resp = self.rpc.call(method, **query)
-            resp.raise_for_status()
-            rpc_reply = self.rpc.codec.loads(resp.content, encoding='utf-8')
-            return self.rpc.response(rpc_reply)
+            return self.rpc.request(method, **query)
         except requests.exceptions.HTTPError as exc:
             logger.exception(exc)
-            raise
+            raise exc
 
     def query(self, params):
-        if not isiterable(params):
-            params = [params]
-        query = self.build_query(params)
-        reply = self._request('DataService.Query', **query)
+        params = params if isiterable(params) else [params]
+        reply = self._request('DataService.Query',
+                              requests=[p.to_rpc() for p in params])
         return QueryReply(reply)
 
-    def write(self, recarray, tbk, isvariablelength=False):
+    def write(self, recarray, tbk, is_variable_length=False):
         data = {}
         data['types'] = [
             recarray.dtype[name].str.replace('<', '')
@@ -111,48 +172,16 @@ class Client(object):
         data['length'] = len(recarray)
         data['startindex'] = {tbk: 0}
         data['lengths'] = {tbk: len(recarray)}
+
         write_request = {}
         write_request['dataset'] = data
-        write_request['is_variable_length'] = isvariablelength
-        writer = {}
-        writer['requests'] = [write_request]
-        try:
-            reply = self.rpc.call("DataService.Write", **writer)
-        except requests.exceptions.ConnectionError:
-            raise requests.exceptions.ConnectionError(
-                "Could not contact server")
-        reply_obj = self.rpc.codec.loads(reply.content, encoding='utf-8')
-        resp = self.rpc.response(reply_obj)
-        return resp
+        write_request['is_variable_length'] = is_variable_length
 
-    def build_query(self, params):
-        reqs = []
-        if not isiterable(params):
-            params = [params]
-        for param in params:
-            req = {
-                'destination': param.tbk,
-            }
-            if param.key_category is not None:
-                req['key_category'] = param.key_category
-            if param.start is not None:
-                req['epoch_start'] = int(param.start.value / (10 ** 9))
-            if param.end is not None:
-                req['epoch_end'] = int(param.end.value / (10 ** 9))
-            if param.limit is not None:
-                req['limit_record_count'] = int(param.limit)
-            if param.limit_from_start is not None:
-                req['limit_from_start'] = bool(param.limit_from_start)
-            if param.functions is not None:
-                req['functions'] = param.functions
-            reqs.append(req)
-        return {
-            'requests': reqs,
-        }
+        return self.rpc.request("DataService.Write", requests=[write_request])
 
     def list_symbols(self):
         reply = self._request('DataService.ListSymbols')
-        if 'Results' in reply.keys():
+        if 'Results' in reply:
             return reply['Results']
         return []
 

--- a/pymarketstore/jsonrpc.py
+++ b/pymarketstore/jsonrpc.py
@@ -8,44 +8,45 @@ class JsonRpcClient(object):
     codec = json
     mimetype = "application/json"
 
-    def __init__(self, endpoint=None):
+    def __init__(self, endpoint):
         self._id = 1
         self._endpoint = endpoint
         self._session = requests.Session()
 
-    def __getattr__(self, method):
-        assert self._endpoint is not None
+    def request(self, rpc_method, **query):
+        reply = self._rpc_request(rpc_method, **query)
+        return self._rpc_response(reply)
 
-        def call(**kwargs):
-            return self._session.post(
-                self._endpoint,
-                data=self.codec.dumps(self.request(method, **kwargs)),
-                headers={"Content-Type": self.mimetype})
-        return call
-
-    def call(self, method, **kwargs):
-        return getattr(self, method)(**kwargs)
-
-    def request(self, method, **kwargs):
-        req = dict(
-            method=method,
-            id=str(self._id),
-            jsonrpc='2.0',
-            params=kwargs,
+    def _rpc_request(self, method, **query):
+        http_resp = self._session.post(
+            self._endpoint,
+            data=self.codec.dumps(dict(
+                method=method,
+                id=str(self._id),
+                jsonrpc='2.0',
+                params=query,
+            )),
+            headers={"Content-Type": self.mimetype}
         )
-        return req
+
+        # FIXME: compat with unittest.mock
+        if not isinstance(requests.Response, type):
+            return http_resp
+
+        http_resp.raise_for_status()
+        return self.codec.loads(http_resp.content, encoding='utf-8')
 
     @staticmethod
-    def response(resp):
-        if 'result' in resp:
-            return resp['result']
+    def _rpc_response(reply):
+        error = reply.get('error', None)
+        if error:
+            raise Exception('{}: {}'.format(error['message'],
+                                            error.get('data', '')))
 
-        if 'error' not in resp:
-            raise Exception('invalid JSON-RPC protocol: missing error')
+        if 'result' in reply:
+            return reply['result']
 
-        raise Exception('{}:\n{}'.format(
-            resp['error']['message'],
-            str(resp['error'].get('data', ''))))
+        raise Exception('invalid JSON-RPC protocol: missing error or result key')
 
 
 class MsgpackRpcClient(JsonRpcClient):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ requests
 six
 urllib3
 pytest
+pytest-cov
 setuptools>=28.8.0
 websocket-client

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,5 @@ exclude =
 test=pytest
 
 [tool:pytest]
+testpaths = tests
 addopts = --verbose --cov pymarketstore --cov-report=term-missing

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,46 +26,39 @@ def test_query(MsgpackRpcClient):
     c = pymkts.Client()
     p = pymkts.Params('BTC', '1Min', 'OHLCV')
     c.query(p)
-    assert MsgpackRpcClient().call.called == 1
+    assert MsgpackRpcClient().request.called == 1
 
 
 @patch('pymarketstore.client.MsgpackRpcClient')
 def test_write(MsgpackRpcClient):
     c = pymkts.Client()
-    data = np.array([(1, 0)], dtype=[('Epoch', 'i8'), ('Ask', 'f4')])
+    data = np.rec.fromrecords([(1, 0)], dtype=[('Epoch', 'i8'), ('Ask', 'f4')])
     tbk = 'TEST/1Min/TICK'
     c.write(data, tbk)
-    assert MsgpackRpcClient().call.called == 1
+    assert MsgpackRpcClient().request.called == 1
 
 
 def test_build_query():
-    c = pymkts.Client("127.0.0.1:5994")
-    p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
-    p2 = pymkts.Params('FORD', '5Min', 'OHLCV', 1000000000, 4294967296)
-    query_dict = c.build_query([p, p2])
-    test_query_dict = {}
-    test_lst = []
-    param_dict1 = {
+    tsla = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
+    ford = pymkts.Params('FORD', '5Min', 'OHLCV', 1000000000, 4294967296)
+
+    assert tsla.to_rpc() == {
         'destination': 'TSLA/1Min/OHLCV',
+        'key_category': 'Symbol/Timeframe/AttributeGroup',
         'epoch_start': 1500000000,
         'epoch_end': 4294967296
     }
-    test_lst.append(param_dict1)
-    param_dict2 = {
+
+    assert ford.to_rpc() == {
         'destination': 'FORD/5Min/OHLCV',
+        'key_category': 'Symbol/Timeframe/AttributeGroup',
         'epoch_start': 1000000000,
         'epoch_end': 4294967296
     }
-    test_lst.append(param_dict2)
-    test_query_dict['requests'] = test_lst
-    assert query_dict == test_query_dict
-
-    query_dict = c.build_query(p)
-    assert query_dict == {'requests': [param_dict1]}
 
 
 @patch('pymarketstore.client.MsgpackRpcClient')
 def test_list_symbols(MsgpackRpcClient):
     c = pymkts.Client()
     c.list_symbols()
-    assert MsgpackRpcClient().call.called == 1
+    assert MsgpackRpcClient().request.called == 1

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -13,19 +13,20 @@ def test_jsonrpc(requests):
     requests.Session().post.return_value = 'dummy_data'
 
     cli = jsonrpc.MsgpackRpcClient('http://localhost:5993/rcp')
-    result = cli.call('DataService.Query', a=1)
+    result = cli._rpc_request('DataService.Query', a=1)
     assert result == 'dummy_data'
     resp = {
         'jsonrpc': '2.0',
         'id': 1,
         'result': {'ok': True},
     }
-    assert cli.response(resp)['ok']
+    assert cli._rpc_response(resp)['ok']
 
     del resp['result']
     resp['error'] = {
         'message': 'Error',
         'data': 'something',
     }
-    with pytest.raises(Exception):
-        cli.response(resp)
+    with pytest.raises(Exception) as e:
+        cli._rpc_response(resp)
+    assert 'Error: something' in str(e)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -42,14 +42,14 @@ testdata2 = literal_eval(r"""
 def test_results():
     reply = results.QueryReply(testdata1)
     assert reply.timezone == 'UTC'
-    assert str(reply) == """QueryReply(QueryResult(DataSet(key=BTC/1Min/OHLCV, shape=(5,), dtype=[('Epoch', '<i8'), ('Open', '<f8'), ('High', '<f8'), ('Low', '<f8'), ('Close', '<f8'), ('Volume', '<f8')])))"""  # noqa
+    assert str(reply) == """<QueryReply datasets=[DataSet(key=BTC/1Min/OHLCV:Symbol/Timeframe/AttributeGroup, shape=(5,), dtype=[('Epoch', '<i8'), ('Open', '<f8'), ('High', '<f8'), ('Low', '<f8'), ('Close', '<f8'), ('Volume', '<f8')])]>"""  # noqa
     assert reply.first().timezone == 'UTC'
     assert reply.first().symbol == 'BTC'
     assert reply.first().timeframe == '1Min'
     assert reply.first().attribute_group == 'OHLCV'
     assert reply.first().df().shape == (5, 5)
     assert list(reply.by_symbols().keys()) == ['BTC']
-    assert reply.keys() == ['BTC/1Min/OHLCV']
+    assert reply.keys() == ['BTC/1Min/OHLCV:Symbol/Timeframe/AttributeGroup']
     assert reply.symbols() == ['BTC']
     assert reply.timeframes() == ['1Min']
 


### PR DESCRIPTION
As I've been digging through the code getting up to speed on this library, it started dawning on me that things could probably be simplified a bit. (It definitely helps when others have taken the first crack at writing the code haha :-D)

Aside from simplification, this PR also fixes/improves:

* a couple pretty subtle bugs in the old `QueryReply`:
  - non-deterministic ordering of (maybe everything? I think it would vary by Python version too). For example the results of iterating over `all()` and `symbols()` would not line up.
  - if multiple timeframes were requested in the same query, `by_symbols` didn't care
  - note: this branch still doesn't correctly handle multiple attribute groups (with the same symbol/timeframe) in the same query. I have some (conceptual) thoughts about backend changes that I think (hope) would make that particular limitation a non-issue, but yea, my Go skills need some work first
* instances of `Params` can now be safely mutated before being passed to `Client`
* the code around `Params` makes slightly fewer assumptions about the format of the time bucket key [TBK handling specifically could use some more thought/improvement, but, I think that might also need to be tackled on the Go backend first before it's really of any practical use here]
* for lack of a better word, de-obfuscated the `JsonRpcClient` class (and as a side benefit, now it doesn't require the calling code to know about internal implementation details)

Not (yet) for merge, contains a few (hopefully somewhat minor) backwards-compatibility breaks...