### PR TITLE
support python-msgpack>=1.0 (remove encoding kwarg from calls to msgpack.loads)

### DIFF
--- a/pymarketstore/jsonrpc.py
+++ b/pymarketstore/jsonrpc.py
@@ -49,7 +49,7 @@ class MsgpackRpcClient(object):
             return http_resp
 
         http_resp.raise_for_status()
-        return self.codec.loads(http_resp.content, encoding='utf-8')
+        return self.codec.loads(http_resp.content)
 
     @staticmethod
     def _rpc_response(reply: Dict) -> str:

--- a/pymarketstore/stream.py
+++ b/pymarketstore/stream.py
@@ -28,7 +28,7 @@ class StreamConn(object):
             self._subscribe(ws, streams)
             while True:
                 r = ws.recv()
-                msg = msgpack.loads(r, encoding='utf-8')
+                msg = msgpack.loads(r)
                 key = msg.get('key')
                 if key is not None:
                     self._dispatch(key, msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msgpack-python
+msgpack
 numpy
 pandas
 requests

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,12 @@ setup(
     keywords='database,pandas,financial,timeseries',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        'msgpack-python',
+        'msgpack',
         'numpy',
         'requests',
         'pandas',
         'six',
         'urllib3',
-        'pytest',
         'websocket-client',
         'protobuf>=3.11.3',
         'grpcio'


### PR DESCRIPTION
This PR adds compatibility with `python-msgpack>=1.0` (and maintains compatibility back to 0.5.2, which was released Feb 2, 2018)

`encoding='utf-8'` is the default on Python 3, see [upstream ref](https://github.com/msgpack/msgpack-python/compare/v0.6.2...v1.0.0#diff-04c6e90faac2675aa89e2176d2eec7d8R52-R58)