### PR TITLE
fix: set max message size for grpc client

### DIFF
--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -23,8 +23,11 @@ class GRPCClient(object):
 
     def __init__(self, endpoint: str = 'localhost:5995'):
         self.endpoint = endpoint
-        # set max message size as 100MB
-        options = [('grpc.max_message_length', 100 * 1024 * 1024)]
+        # set max message sizes
+        options = [
+            ('grpc.max_send_message_length', 1 << 31 - 1),
+            ('grpc.max_receive_message_length', 1 << 31 - 1),
+        ]
         self.channel = grpc.insecure_channel(endpoint, options=options)
         self.stub = gp.MarketstoreStub(self.channel)
 

--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -23,7 +23,9 @@ class GRPCClient(object):
 
     def __init__(self, endpoint: str = 'localhost:5995'):
         self.endpoint = endpoint
-        self.channel = grpc.insecure_channel(endpoint)
+        # set max message size as 100MB
+        options = [('grpc.max_message_length', 100 * 1024 * 1024)]
+        self.channel = grpc.insecure_channel(endpoint, options=options)
         self.stub = gp.MarketstoreStub(self.channel)
 
     def query(self, params: Union[Params, List[Params]]) -> QueryReply:

--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -25,8 +25,8 @@ class GRPCClient(object):
         self.endpoint = endpoint
         # set max message sizes
         options = [
-            ('grpc.max_send_message_length', 1 << 31 - 1),
-            ('grpc.max_receive_message_length', 1 << 31 - 1),
+            ('grpc.max_send_message_length', 1 * 1024 ** 3),  # 1GB
+            ('grpc.max_receive_message_length', 1 * 1024 ** 3),  # 1GB
         ]
         self.channel = grpc.insecure_channel(endpoint, options=options)
         self.stub = gp.MarketstoreStub(self.channel)


### PR DESCRIPTION
default message size limit is 4MB ([ref](https://github.com/tensorflow/serving/issues/1382))
but our usage might exceed the limit