### PR TITLE
Add support for writing pandas DataFrame and Series

### DIFF
--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -51,9 +51,6 @@ class Client:
         """
         return self.client.query(params)
 
-    def _build_query(self, params: Union[Params, List[Params]]) -> Dict:
-        return self.client.build_query(params)
-
     def write(self, recarray: np.array, tbk: str, isvariablelength: bool = False) -> str:
         """
         execute WRITE to MarketStore server

--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
-
 import logging
-import re
-from typing import List, Dict, Union
-
 import numpy as np
+import re
+
+from typing import List, Dict, Union
 
 from .grpc_client import GRPCClient
 from .jsonrpc_client import JsonRpcClient
@@ -13,37 +11,25 @@ from .results import QueryReply
 
 logger = logging.getLogger(__name__)
 
-data_type_conv = {
-    '<f4': 'f',
-    '<f8': 'd',
-    '<i4': 'i',
-    '<i8': 'q',
-}
-
 http_regex = re.compile(r'^https?://(.+):\d+/rpc')  # http:// or https://
 
 
 class Client:
     def __init__(self, endpoint: str = 'http://localhost:5993/rpc', grpc: bool = False):
-        if grpc:
-            match = re.findall(http_regex, endpoint)
-
-            # when endpoint is specified in "http://{host}:{port}/rpc" format,
-            # extract the host and initialize GRPC client with default port(5995) for compatibility
-            if len(match) != 0:
-                host = match[0] if match[0] is not "" else "localhost"  # default host is "localhost"
-                self.endpoint = "{}:5995".format(host)  # default port is 5995
-                self.client = GRPCClient(self.endpoint)
-                return
-            else:
-                self.endpoint = endpoint
-                self.client = GRPCClient(self.endpoint)
-                return
-
         self.endpoint = endpoint
-        self.client = JsonRpcClient(self.endpoint)
+        if not grpc:
+            self.client = JsonRpcClient(self.endpoint)
+            return
 
-    def query(self, params: Params) -> QueryReply:
+        # when endpoint is specified in "http://{host}:{port}/rpc" format,
+        # extract the host and initialize GRPC client with default port(5995) for compatibility
+        match = re.findall(http_regex, endpoint)
+        if match:
+            host = match[0] if match[0] != "" else "localhost"  # default host is "localhost"
+            self.endpoint = "{}:5995".format(host)  # default port is 5995
+        self.client = GRPCClient(self.endpoint)
+
+    def query(self, params: Union[Params, List[Params]]) -> QueryReply:
         """
         execute QUERY to MarketStore server
         :param params: Params object used to query

--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -1,22 +1,16 @@
-from __future__ import absolute_import
-
-import logging
-
 import grpc
-
-import pymarketstore.proto.marketstore_pb2 as proto
-import pymarketstore.proto.marketstore_pb2_grpc as gp
-from .params import Params
-from .results import QueryReply
-
+import logging
 import numpy as np
+
 from typing import List, Union
 
+from .params import Params
+from .proto import marketstore_pb2 as proto
+from .proto import marketstore_pb2_grpc as gp
+from .results import QueryReply
+from .utils import is_iterable
+
 logger = logging.getLogger(__name__)
-
-
-def isiterable(something):
-    return isinstance(something, (list, tuple, set))
 
 
 class GRPCClient(object):
@@ -27,7 +21,7 @@ class GRPCClient(object):
         self.stub = gp.MarketstoreStub(self.channel)
 
     def query(self, params: Union[Params, List[Params]]) -> QueryReply:
-        if not isiterable(params):
+        if not is_iterable(params):
             params = [params]
 
         reply = self.stub.Query(self._build_query(params))
@@ -67,7 +61,7 @@ class GRPCClient(object):
         return self.stub.Write(req)
 
     def _build_query(self, params: Union[Params, List[Params]]) -> proto.MultiQueryRequest:
-        if not isiterable(params):
+        if not is_iterable(params):
             params = [params]
 
         return proto.MultiQueryRequest(requests=[p.to_query_request() for p in params])

--- a/pymarketstore/jsonrpc_client.py
+++ b/pymarketstore/jsonrpc_client.py
@@ -1,37 +1,22 @@
-from __future__ import absolute_import
-
 import logging
-import re
-from typing import Any
-from typing import Union, Dict, List
-
 import numpy as np
-import pandas as pd
+import re
 import requests
+
+from typing import Union, Dict, List
 
 from .jsonrpc import MsgpackRpcClient
 from .params import Params
 from .results import QueryReply
 from .stream import StreamConn
+from .utils import is_iterable
 
 logger = logging.getLogger(__name__)
 
 
-def isiterable(something: Any) -> bool:
-    return isinstance(something, (list, tuple, set))
-
-
-def get_timestamp(value: Union[int, str]) -> pd.Timestamp:
-    if value is None:
-        return None
-    if isinstance(value, (int, np.integer)):
-        return pd.Timestamp(value, unit='s')
-    return pd.Timestamp(value)
-
-
 class JsonRpcClient(object):
 
-    def __init__(self, endpoint: str = 'http://localhost:5993/rpc', ):
+    def __init__(self, endpoint: str = 'http://localhost:5993/rpc'):
         self.endpoint = endpoint
         self.rpc = MsgpackRpcClient(self.endpoint)
 
@@ -42,8 +27,8 @@ class JsonRpcClient(object):
             logger.exception(exc)
             raise
 
-    def query(self, params: Params) -> QueryReply:
-        if not isiterable(params):
+    def query(self, params: Union[Params, List[Params]]) -> QueryReply:
+        if not is_iterable(params):
             params = [params]
 
         reply = self._request('DataService.Query', requests=[

--- a/pymarketstore/params.py
+++ b/pymarketstore/params.py
@@ -45,6 +45,26 @@ class Params(object):
             setattr(self, key, val)
         return self
 
+    def to_query_request(self) -> dict:
+        query = {'destination': self.tbk}
+        if self.key_category is not None:
+            query['key_category'] = self.key_category
+        if self.start is not None:
+            query['epoch_start'], start_nanos = divmod(self.start.value, 10 ** 9)
+            if start_nanos != 0:
+                query['epoch_start_nanos'] = start_nanos
+        if self.end is not None:
+            query['epoch_end'], end_nanos = divmod(self.end.value, 10 ** 9)
+            if end_nanos != 0:
+                query['epoch_end_nanos'] = end_nanos
+        if self.limit is not None:
+            query['limit_record_count'] = self.limit
+        if self.limit_from_start is not None:
+            query['limit_from_start'] = bool(self.limit_from_start)
+        if self.functions is not None:
+            query['functions'] = self.functions
+        return query
+
     def __repr__(self) -> str:
         content = ('tbk={}, start={}, end={}, '.format(
             self.tbk, self.start, self.end,

--- a/pymarketstore/params.py
+++ b/pymarketstore/params.py
@@ -1,22 +1,6 @@
 from typing import Union, List, Any
-import pandas as pd
-import numpy as np
 
-def get_timestamp(value: Union[int, str]) -> pd.Timestamp:
-    if value is None:
-        return None
-    if isinstance(value, (int, np.integer)):
-        return pd.Timestamp(value, unit='s')
-    return pd.Timestamp(value)
-
-
-def isiterable(something: Any) -> bool:
-    """
-    check if something is a list, tuple or set
-    :param something: any object
-    :return: bool. true if something is a list, tuple or set
-    """
-    return isinstance(something, (list, tuple, set))
+from .utils import get_timestamp, is_iterable
 
 
 class Params(object):
@@ -25,7 +9,7 @@ class Params(object):
                  start: Union[int, str] = None, end: Union[int, str] = None,
                  limit: int = None, limit_from_start: bool = None,
                  columns: List[str] = None):
-        if not isiterable(symbols):
+        if not is_iterable(symbols):
             symbols = [symbols]
         self.tbk = ','.join(symbols) + "/" + timeframe + "/" + attrgroup
         self.key_category = None  # server default

--- a/pymarketstore/utils.py
+++ b/pymarketstore/utils.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+
+from typing import Any, Union
+
+
+def get_timestamp(value: Union[int, str]) -> Union[pd.Timestamp, None]:
+    if value is None or isinstance(value, pd.Timestamp):
+        return value
+    if isinstance(value, (int, np.integer)):
+        return pd.Timestamp(value, unit='s')
+    return pd.Timestamp(value)
+
+
+def is_iterable(something: Any) -> bool:
+    """
+    check if something is a list, tuple or set
+    :param something: any object
+    :return: bool. true if something is a list, tuple or set
+    """
+    return isinstance(something, (list, tuple, set))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,12 +10,6 @@ except ImportError:
 import pytest
 
 
-def test_init():
-    p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
-    tbk = "TSLA/1Min/OHLCV"
-    assert p.tbk == tbk
-
-
 params = [
     ("http://127.0.0.1:5994/rpc", False, "http://127.0.0.1:5994/rpc", pymkts.jsonrpc_client.JsonRpcClient),
     ("http://192.168.1.10:5993/rpc", True, "192.168.1.10:5995", pymkts.grpc_client.GRPCClient),
@@ -48,32 +42,6 @@ def test_write(MsgpackRpcClient):
     tbk = 'TEST/1Min/TICK'
     c.write(data, tbk)
     assert MsgpackRpcClient().call.called == 1
-
-
-def test_build_query():
-    c = pymkts.Client("127.0.0.1:5994")
-    p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
-    p2 = pymkts.Params('FORD', '5Min', 'OHLCV', 1000000000, 4294967296)
-    query_dict = c._build_query([p, p2])
-    test_query_dict = {}
-    test_lst = []
-    param_dict1 = {
-        'destination': 'TSLA/1Min/OHLCV',
-        'epoch_start': 1500000000,
-        'epoch_end': 4294967296
-    }
-    test_lst.append(param_dict1)
-    param_dict2 = {
-        'destination': 'FORD/5Min/OHLCV',
-        'epoch_start': 1000000000,
-        'epoch_end': 4294967296
-    }
-    test_lst.append(param_dict2)
-    test_query_dict['requests'] = test_lst
-    assert query_dict == test_query_dict
-
-    query_dict = c._build_query(p)
-    assert query_dict == {'requests': [param_dict1]}
 
 
 @patch('pymarketstore.jsonrpc_client.MsgpackRpcClient')

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -50,7 +50,7 @@ def test_build_query():
     p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
 
     # --- when ---
-    query = c.build_query([p])
+    query = c._build_query([p])
 
     # --- then ---
     assert query == MultiQueryRequest(
@@ -80,6 +80,7 @@ def test_destroy(stub):
 
     # --- then ---
     assert c.stub.Destroy.called == 1
+
 
 @patch('pymarketstore.proto.marketstore_pb2_grpc.MarketstoreStub')
 def test_server_version(stub):

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,31 @@
+import pymarketstore as pymkts
+
+
+def test_init():
+    p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
+    tbk = "TSLA/1Min/OHLCV"
+    assert p.tbk == tbk
+
+
+def test_to_query_request():
+    p = pymkts.Params('TSLA', '1Min', 'OHLCV', 1500000000, 4294967296)
+    assert p.to_query_request() == {
+        'destination': 'TSLA/1Min/OHLCV',
+        'epoch_start': 1500000000,
+        'epoch_end': 4294967296,
+    }
+
+    p2 = pymkts.Params(symbols=['FORD', 'TSLA'],
+                       timeframe='5Min',
+                       attrgroup='OHLCV',
+                       start=1000000000,
+                       end=4294967296,
+                       limit=200,
+                       limit_from_start=False)
+    assert p2.to_query_request() == {
+        'destination': 'FORD,TSLA/5Min/OHLCV',
+        'epoch_start': 1000000000,
+        'epoch_end': 4294967296,
+        'limit_record_count': 200,
+        'limit_from_start': False,
+    }


### PR DESCRIPTION
This PR

* adds support for writing pandas DataFrame and Series objects (replaces #31)
* consolidates as much logic as possible between the JsonRpcClient and GRPCClient (but unfortunately the request formats are slightly different, so there's still some extra verbosity)
* I have tested this writing 32bit and 64bit values, both work, however the usability of this PR is much improved by [marketstore #363](https://github.com/alpacahq/marketstore/pull/363)
  * without 363, the client is responsible for knowing ahead-of-time the which types marketstore uses for each TBK. Which IMO is kinda not great :)

NOTE: branched off of #52, so hopefully that will be merged sooner rather than later