### PR TITLE
fix: remove the character indicating the byte-order in the dtype

### DIFF
--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -42,7 +42,7 @@ class GRPCClient(object):
 
     def write(self, recarray: np.array, tbk: str, isvariablelength: bool = False) -> proto.MultiServerResponse:
         types = [
-            recarray.dtype[name].str.replace('<', '')
+            recarray.dtype[name].str.replace('<', '').replace('|', '')
             for name in recarray.dtype.names
         ]
         names = recarray.dtype.names

--- a/pymarketstore/jsonrpc_client.py
+++ b/pymarketstore/jsonrpc_client.py
@@ -52,7 +52,7 @@ class JsonRpcClient(object):
     def write(self, recarray: np.array, tbk: str, isvariablelength: bool = False) -> str:
         data = {}
         data['types'] = [
-            recarray.dtype[name].str.replace('<', '')
+            recarray.dtype[name].str.replace('<', '').replace('|', '')
             for name in recarray.dtype.names
         ]
         data['names'] = recarray.dtype.names


### PR DESCRIPTION
https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html

some dtypes contain "|" that marketstore server doesn't understand