### PR TITLE
feat: execute SQL from pymarketstore

### DIFF
--- a/pymarketstore/client.py
+++ b/pymarketstore/client.py
@@ -51,6 +51,14 @@ class Client:
         """
         return self.client.query(params)
 
+    def sql(self, statements: Union[str, List[str]]) -> QueryReply:
+        """
+        execute SQL to MarketStore server
+        :param statements: List of SQL statements in a string
+        :return: QueryReply object
+        """
+        return self.client.sql(statements)
+
     def _build_query(self, params: Union[Params, List[Params]]) -> Dict:
         return self.client.build_query(params)
 

--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -40,6 +40,22 @@ class GRPCClient(object):
 
         return QueryReply.from_grpc_response(reply)
 
+    def sql(self, statements: Union[str, List[str]]) -> QueryReply:
+        if not isiterable(statements):
+            statements = [statements]
+
+        reqs = proto.MultiQueryRequest(requests=[])
+
+        for statement in statements:
+            req = proto.QueryRequest(
+                is_sql_statement=True,
+                sql_statement=statement,
+            )
+            reqs.requests.append(req)
+
+        reply = self.stub.Query(reqs)
+        return QueryReply.from_grpc_response(reply)
+
     def create(self, tbk: str, dtype: List[Tuple[str, str]],
                isvariablelength: bool = False) -> proto.MultiServerResponse:
         # dtype: e.g. [('Epoch', 'i8'), ('Ask', 'f4')]

--- a/pymarketstore/jsonrpc_client.py
+++ b/pymarketstore/jsonrpc_client.py
@@ -49,6 +49,22 @@ class JsonRpcClient(object):
         reply = self._request('DataService.Query', **query)
         return QueryReply.from_response(reply)
 
+    def sql(self, statements: Union[str, List[str]]) -> QueryReply:
+        if not isiterable(statements):
+            statements = [statements]
+
+        reqs: List[Dict] = []
+        for statement in statements:
+            req = {
+                "is_sqlstatement": True,
+                "sql_statement": statement,
+            }
+            reqs.append(req)
+
+        param = {'requests': reqs}
+        reply = self._request('DataService.Query', **param)
+        return QueryReply.from_response(reply)
+
     def create(self, tbk: str, dtype: List[Tuple[str, str]], isvariablelength: bool = False) -> dict:
         # dtype: e.g. [('Epoch', 'i8'), ('Ask', 'f4')]
         req = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,6 +42,14 @@ def test_query(MsgpackRpcClient):
 
 
 @patch('pymarketstore.jsonrpc_client.MsgpackRpcClient')
+def test_sql(MsgpackRpcClient):
+    c = pymkts.Client()
+    s = "SELECT * FROM `BTC/1Min/OHLCV`"
+    c.sql(s)
+    assert MsgpackRpcClient().call.called == 1
+
+
+@patch('pymarketstore.jsonrpc_client.MsgpackRpcClient')
 def test_create(MsgpackRpcClient):
     c = pymkts.Client()
     dtype = [('Epoch', 'i8'), ('Bid', 'f4'), ('Ask', 'f4')]

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -29,6 +29,17 @@ def test_query(stub):
     # --- then ---
     assert c.stub.Query.called == 1
 
+@patch('pymarketstore.proto.marketstore_pb2_grpc.MarketstoreStub')
+def test_sql(stub):
+    # --- given ---
+    c = pymkts.GRPCClient()
+    s = "SELECT * FROM `BTC/1Min/OHLCV`"
+
+    # --- when ---
+    c.sql(s)
+
+    # --- then ---
+    assert c.stub.Query.called == 1
 
 @patch('pymarketstore.proto.marketstore_pb2_grpc.MarketstoreStub')
 def test_create(stub):


### PR DESCRIPTION
## WHAT
- SQL support from pymarketstore

## WHY
- SQL feature is sometimes more powerful than the normal query, and can be used to reduce traffic between a marketstore server and client.

## EXAMPLE
```
>>> import numpy as np, pandas as pd, pymarketstore as pymkts
>>> cli = pymkts.Client()
>>> reply = cli.sql("SELECT * FROM `USDJPY/1Min/OHLCV` WHERE Epoch Between '2018-01-01' AND '2018-01-02';")
>>> reply.first().df()
                                 Open        High         Low       Close  Volume
Epoch                                                                            
2018-01-01 16:00:00+00:00  112.579002  112.589996  112.579002  112.585999      61
2018-01-01 16:01:00+00:00  112.586998  112.597000  112.585999  112.592003     109
2018-01-01 16:02:00+00:00  112.593002  112.597000  112.588997  112.589996      38
2018-01-01 16:03:00+00:00  112.592003  112.642998  112.589996  112.637001     124
2018-01-01 16:04:00+00:00  112.638000  112.657997  112.637001  112.653000     136
...                               ...         ...         ...         ...     ...
2018-01-01 23:55:00+00:00  112.666000  112.667999  112.660004  112.667999      32
2018-01-01 23:56:00+00:00  112.668999  112.681999  112.667000  112.672997      46
2018-01-01 23:57:00+00:00  112.675003  112.678001  112.663002  112.671997      60
2018-01-01 23:58:00+00:00  112.668999  112.677002  112.664001  112.667000      49
2018-01-01 23:59:00+00:00  112.666000  112.667000  112.657997  112.663002      48
[464 rows x 5 columns]
```
