### PR TITLE
add: enable aggregator functions on Query

### DIFF
--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -137,7 +137,7 @@ class GRPCClient(object):
             if param.limit_from_start is not None:
                 req.limit_from_start = bool(param.limit_from_start)
             if param.functions is not None:
-                req.functions = param.functions
+                req.functions.extend(param.functions)
             reqs.requests.append(req)
         return reqs
 

--- a/pymarketstore/params.py
+++ b/pymarketstore/params.py
@@ -36,7 +36,7 @@ class Params(object):
     def __init__(self, symbols: Union[List[str], str], timeframe: str, attrgroup: str,
                  start: Union[int, str] = None, end: Union[int, str] = None,
                  limit: int = None, limit_from_start: bool = None,
-                 columns: List[str] = None):
+                 columns: List[str] = None, functions: List[str] = None):
         if not isiterable(symbols):
             symbols = [symbols]
         self.tbk = ','.join(symbols) + "/" + timeframe + "/" + attrgroup
@@ -46,7 +46,7 @@ class Params(object):
         self.limit = limit
         self.limit_from_start = limit_from_start
         self.columns = columns
-        self.functions = None
+        self.functions = functions
 
     def set(self, key: str, val: Any):
         if not hasattr(self, key):


### PR DESCRIPTION
## WHAT
- enable Aggregator Functions on Query.

example usage (convert 1min Candle data to 12min Candle data and return): 
```
import numpy as np, pandas as pd, pymarketstore as pymkts

if __name__ == "__main__":
    client = pymkts.Client()
    param = pymkts.Params('USDJPY', '1Min', 'OHLCV', limit=100,
        functions=["CandleCandler ('12Min',Open,High,Low,Close,Avg::Volume,Sum::Volume)"])
    reply = client.query(param)
    print(reply.first().df())
```

## WHY
- Aggregator functions are implemented in marketstore server side but it was not enabled from pymarketstore client side