### PR TITLE
fix: enable column filtering on query

### DIFF
--- a/pymarketstore/grpc_client.py
+++ b/pymarketstore/grpc_client.py
@@ -138,6 +138,8 @@ class GRPCClient(object):
                 req.limit_from_start = bool(param.limit_from_start)
             if param.functions is not None:
                 req.functions.extend(param.functions)
+            if param.columns is not None:
+                req.columns = param.columns
             reqs.requests.append(req)
         return reqs
 

--- a/pymarketstore/jsonrpc_client.py
+++ b/pymarketstore/jsonrpc_client.py
@@ -139,6 +139,8 @@ class JsonRpcClient(object):
                 req['limit_from_start'] = bool(param.limit_from_start)
             if param.functions is not None:
                 req['functions'] = param.functions
+            if param.columns is not None:
+                req['columns'] = param.columns
             reqs.append(req)
         return {
             'requests': reqs,


### PR DESCRIPTION
## WHAT
- bugfix: add `columns` query param

## WHY
- The function to specify columns to retrieve at query was implemented, but for some reason, it is not included in the request parameter, so it has not been enabled.